### PR TITLE
fix: argument 'properties' is of type <class 'list'> and we were unab…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,13 +61,12 @@ extra_xml_conf: {}
 
 xml_conf: "{{ base_xml_conf | combine(extra_xml_conf) }}"
 
-#
-
+# Logback configuration
+base_logback_properties: {}
 extra_logback_properties: {}
 
-logback_properties: "{{ extra_logback_properties }}"
+logback_properties: "{{ base_logback_properties | combine(extra_logback_properties) }}"
 
-#
 
 __license_type: "{{ license_type | default('trial') }}"
 __license_valid_options: 


### PR DESCRIPTION
This is caused when list of string properties like below are passed to module and there are no concat with a map. 

```
13:30:34 
13:30:34 TASK [cloud-server : update logback properties file] ***************************
13:30:34 task path: /home/jenkins/workspace/Cloud_Server/roles/cloud-server/tasks/linux-install.yml:141
13:30:35 fatal: [mastercloud.experitest.com]: FAILED! => {"changed": false, "msg": "argument 'properties' is of type <class 'list'> and we were unable to convert to dict: <class 'list'> cannot be converted to a dict"}
13:30:35 
```

This PR introduces a workaround to convert the list to map by way of concat.